### PR TITLE
例外処理

### DIFF
--- a/examples/Test1.java
+++ b/examples/Test1.java
@@ -41,5 +41,6 @@ class Test1 {
     Park park = new Park()/*@ [][p1,p2] @*/;
     Animal animal = park.animal;
     assert (animal instanceof Cat);
+    ((Cat) animal).nyan()/*@ [][] @*/;
   }
 }

--- a/src/main/java/Constraint.java
+++ b/src/main/java/Constraint.java
@@ -45,13 +45,17 @@ public class Constraint {
                                         HashMap<String, ObjectType> c,
                                         ArrayList<String> userLocs,
                                         ArrayList<String> formalLocs){
+        //要求する位置の数が異なる場合
+        if(formalLocs.size() != userLocs.size()){
+            return false;
+        }
+
         var substitutedC = substitute(c, userLocs, formalLocs);
 
         for (var location : substitutedC.keySet()) {
 
             //c[formalLocs/userLocs]にある位置がc_sになかったら
             if(!c_s.containsKey(location)){
-                System.err.println(location+" is not found");
                 return false;
             }
             var subObjectType = c_s.get(location);
@@ -59,7 +63,6 @@ public class Constraint {
 
             //オブジェクトのクラスが部分型関係になっているか
             if(!isSubClass(subObjectType, objectType)){
-                System.err.println(subObjectType.className+" is not subclass of "+ objectType.className);
                 return false;
             }
 
@@ -69,13 +72,11 @@ public class Constraint {
 
                 //そもそもフィールドがない
                 if(subType == null){
-                    System.err.println(field+" is not found");
                     return false;
                 }
 
                 //部分型じゃない
                 if(!subType.subType(objectType.fieldTypes.get(field))){
-                    System.err.println(field+" is not found");
                     return false;
                 }
             }

--- a/src/main/java/Data.java
+++ b/src/main/java/Data.java
@@ -4,4 +4,6 @@ public class Data {
   public static HashMap<String, Class> clsTable;
   public static ArrayList<DebugInfo> mainDebugInfo = new ArrayList<>();
   public static String sourceFile;
+  public static String error;
+  public static int errorLine;
 }

--- a/src/main/java/MainController.java
+++ b/src/main/java/MainController.java
@@ -61,9 +61,15 @@ public class MainController {
         //main関数の型付け
         var sb = new StringBuilder();
         for (var debugInfo : Data.mainDebugInfo) {
-            sb.append("Line ").append(debugInfo.line).append(": ").append(debugInfo.statement).append("\n");
+            sb.append("Line ").append(debugInfo.line).append(":").append("\n");
             sb.append("TypingEnvironment: ").append(debugInfo.typeEnv).append("\n");
             sb.append("Constraint: ").append(debugInfo.constraint).append("\n\n");
+        }
+
+        if(Data.error != null){
+            sb.append("Line ").append(Data.errorLine).append(":").append("\n");
+            sb.append("Error: ");
+            sb.append(Data.error);
         }
         resultTextArea.setText(sb.toString());
 
@@ -92,6 +98,8 @@ public class MainController {
             sb.append("\n");
             clsTableSb.append(sb.toString());
         }
+
+
         ctTextArea.setText(clsTableSb.toString());
     }
 


### PR DESCRIPTION
## 作業内容
- 構文解析
  - 構文解析で最初の例外が発生したときにそこで止めて型検査を行わない
    - Antlrの元々の処理ではそのまま構文解析を続行していた
  - 構文解析で例外が起きたときの簡易的なメッセージを追加
    - 例外名
    - 例外が発生した場所
- 型検査  
  - 型検査に失敗したときに、以降の行で型検査を行わないようにする 
- UI
  - 型検査が通ったところまで型環境と制約を出力する
    - 簡易的なメッセージを出力する
      - 型付けが失敗した行
      - 型付けができなかった理由